### PR TITLE
Dockerize the Flask To-Do App

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,85 @@
-# Todo App
+# 📝 Flask To-Do App (Dockerized)
 
-This is a simple Todo application built using Python and SQLite. The application allows users to add, view, and delete tasks. The data is stored in a SQLite database and the front-end is rendered using the Jinja2 template engine.
+This is a simple To-Do web application built using **Flask** and containerized with **Docker**.
 
-## Requirements
-- Python 3.x
-- Flask
-- SQLite3
+It provides basic task management with a Jinja2-rendered UI.  
+This fork adds full Docker support for easy setup, testing, and portability.
 
-## Installation
-1. Clone the repository git clone 
+---
 
-    `https://github.com/pj8912/todo-app.git`
+## 🚀 Getting Started (with Docker Compose)
 
-2. Install the required packages
-    
-    `pip install -r requirements.txt`
+### 📦 Prerequisites
 
-3. Create the database
-    
-    `python db_create.py`
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
 
-## Usage
-1. Start the development server
-    python app.py
+---
 
-2. Open `http://localhost:5000` in your web browser
+### 🛠 Steps to Run
 
+1. **Clone the repository**:
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/todo-app.git
+   cd todo-app
+   ```
+
+2. **Switch to the dockerized branch**:
+   ```bash
+   git checkout dockerize
+   ```
+
+3. **Build and run the containers**:
+   ```bash
+   docker-compose up --build
+   ```
+
+4. **Visit the app in your browser**:
+   [http://localhost:5000](http://localhost:5000)
+
+---
+
+## 📁 Project Structure
+
+```
+.
+├── app.py               # Main Flask application
+├── db_create.py         # Database initializer
+├── requirements.txt     # Python dependencies
+├── templates/           # HTML templates (Jinja2)
+├── docker/
+│   └── Dockerfile       # Dockerfile for building the app image
+├── docker-compose.yml   # Compose configuration
+└── README.md            # You're reading it!
+```
+
+---
+
+## 🐳 Docker Overview
+
+| Component        | Description                                 |
+|------------------|---------------------------------------------|
+| Base Image       | `python:3.12-slim`                          |
+| Web Server       | Flask's built-in development server        |
+| App Port         | Exposes port `5000`                        |
+| Dockerfile Path  | `./docker/Dockerfile`                     |
+| Volume (optional)| `/app/data` (can be used for persistence)  |
+
+> Note: The app listens on `0.0.0.0` inside the container to be accessible from host.
+
+---
+
+## 📌 Notes
+
+- This setup is **intended for development/demo purposes**.
+- For production deployment:
+  - Replace `flask run` with `gunicorn` or `uWSGI`.
+  - Use a production-ready WSGI server.
+  - Configure environment variables and database security.
+
+---
+
+## 📄 License & Attribution
+
+- Original project: [pj8912/todo-app](https://github.com/pj8912/todo-app)
+- Dockerized and maintained by: [YOUR_USERNAME](https://github.com/YOUR_USERNAME)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 This is a simple To-Do web application built using **Flask** and containerized with **Docker**.
 
-It provides basic task management with a Jinja2-rendered UI.  
-This fork adds full Docker support for easy setup, testing, and portability.
+This is a simple Todo application built using Python and SQLite. The application allows users to add, view, and delete tasks. The data is stored in a SQLite database and the front-end is rendered using the Jinja2 template engine.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,3 @@ This fork adds full Docker support for easy setup, testing, and portability.
   - Use a production-ready WSGI server.
   - Configure environment variables and database security.
 
----
-
-## 📄 License & Attribution
-
-- Original project: [pj8912/todo-app](https://github.com/pj8912/todo-app)
-- Dockerized and maintained by: [YOUR_USERNAME](https://github.com/YOUR_USERNAME)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+    ports:
+      - "5000:5000"
+    volumes:
+      - todo_data:/app
+
+volumes:
+  todo_data:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py  db_create.py   /app/
+COPY templates /app/templates/
+
+
+RUN python db_create.py
+
+EXPOSE 5000
+
+ENV FLASK_APP=app.py
+ENV FLASK_RUN_HOST=0.0.0.0
+
+CMD ["flask", "run"]


### PR DESCRIPTION
This pull request adds Docker support to the Flask To-Do App.

### Changes made:
- Added a `Dockerfile` for building a container image.
- Added a `docker-compose.yml` for simplified local development.
- Updated the `README.md` with instructions on how to run the app using Docker.

### Why:
These changes make the app easier to set up and run in isolated environments, improving portability and simplifying deployment and testing.

Let me know if you'd like any changes or improvements. 🙂
